### PR TITLE
Add note about sticky bit requirement for /tmp

### DIFF
--- a/sysadmin/security.md
+++ b/sysadmin/security.md
@@ -116,3 +116,9 @@ volumes:
   - /var/manyfold/app_tmp:/usr/src/app/tmp
   - /var/manyfold/log:/usr/src/app/log
 ```
+
+Be sure to set the sticky bit for the volume mounted to `/tmp`. Using the example above, you can run this command on the host system:
+
+```shell
+chmod 1777 /var/manyfold/sys_tmp/
+```


### PR DESCRIPTION
The `/tmp` directory requires the sticky bit for uploads to function correctly. This change adds a note after the docker compose example with the `chmod` command needed.
