### PR TITLE
Updating monitoring admin doc

### DIFF
--- a/sysadmin/monitoring.md
+++ b/sysadmin/monitoring.md
@@ -7,6 +7,6 @@ nav_order: 2
 
 In order to monitor application uptime, you can use the `/health` endpoint.
 
-This is a minimal endpoint that will just return a `200 OK` with the JSON payload `{"status":"OK"}` if the application is running.
+This is a built in rails health check that will just return a `200 OK` and a green screen in your browser if the application is running.
 
 Point your uptime monitor at that, and you'll soon know if anything goes badly wrong.


### PR DESCRIPTION
Previously the `/health` endpoint was returning a basic JSON object. It's now using the built-in rails HealthController. The built-in controller returns a green screen and a 200 OK. I've updated the doc to reflect that.

Here's an example of the output from the endpoint:

```
<!DOCTYPE html><html><body style="background-color: green"></body></html>
```